### PR TITLE
修改初始化堆大小为512MB(同时将malloc触发gc的限制设置为和初始化堆的大小相同); 使SCM解释器默认区分symbol的大小写,…

### DIFF
--- a/scm/setjump.h
+++ b/scm/setjump.h
@@ -58,7 +58,7 @@
    INIT_MALLOC_LIMIT is the initial amount of malloc usage which will
    trigger a GC. */
 
-#define INIT_HEAP_SIZE (8000000L*sizeof(cell))
+#define INIT_HEAP_SIZE (32000000L*sizeof(cell))
 #define MIN_HEAP_SEG_SIZE (2000L*sizeof(cell))
 #ifdef _QC
 # define HEAP_SEG_SIZE 32400L


### PR DESCRIPTION
… 并增加--with-symbol-case-fold的启动参数以关闭区分symbol的大小写;